### PR TITLE
JPEG comparison graph created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 node_modules
-data/mnist/*
+data/mnist
+data/MNIST
 tmp/*
 params/*
-!params/model_MNIST_params_0.1.pth
+plots/*

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -2,35 +2,10 @@ import os
 from torch.utils.data import Dataset
 from torchvision.transforms import ToTensor
 from PIL import Image
-
-class NIHChestXrayDataset(Dataset):
-    def __init__(self, root_dir, split='train'):
-        self.root_dir = root_dir
-        self.split = split
-
-    def __len__(self):
-        if self.split == 'train':
-            return 100000
-        elif self.split == 'val':
-            return 10000
-        elif self.split == 'test':
-            return 10000
-
-    def __getitem__(self, idx):
-        if self.split == 'train':
-            image_path = os.path.join(self.root_dir, 'train', f'{idx}.png')
-        elif self.split == 'val':
-            image_path = os.path.join(self.root_dir, 'val', f'{idx}.png')
-        elif self.split == 'test':
-            image_path = os.path.join(self.root_dir, 'test', f'{idx}.png')
-
-        image = Image.open(image_path)
-        image = ToTensor()(image)
-
-        return image
+from torchxrayvision.datasets import CheX_Dataset
 
 if __name__ == '__main__':
-    dataset = NIHChestXrayDataset('/path/to/dataset')
+    dataset = CheX_Dataset("/data/user3_data/chexpertchestxrays-u20210408/", csvpath="/data/user3_data/chexpertchestxrays-u20210408/train_visualCheXbert.csv")
     print(len(dataset))
     image, label = dataset[0]
     print(image.size())

--- a/src/model.py
+++ b/src/model.py
@@ -144,7 +144,7 @@ class MNIST_Coder(nn.Module):
             quantized = uniform_quantizer(features)
             output = self.inverse_transform(quantized)
         return output, quantized
-
+# TODO look at batch norm and/or removing bias from the conv layers
 class MNIST_FCNN(nn.Module):
     def __init__(self):
         super(MNIST_FCNN, self).__init__()
@@ -153,7 +153,7 @@ class MNIST_FCNN(nn.Module):
             nn.Conv2d(1, 16, 3, stride=2, padding=1),  # Output: (16, 14, 14)
             nn.ReLU(),
             nn.Conv2d(16, 32, 3, stride=2, padding=1), # Output: (32, 7, 7)
-            nn.ReLU(),
+            nn.ReLU(), 
             nn.Conv2d(32, 64, 7)                      # Output: (64, 1, 1)
         )
         # Decoder layers
@@ -176,7 +176,6 @@ class MNIST_FCNN(nn.Module):
             quantized = uniform_quantizer(features)
             output = self.inverse_transform(quantized)
         return output, quantized
-
 
 class MNIST_VAE(nn.Module):
     def __init__(self):

--- a/src/test_fcnn.py
+++ b/src/test_fcnn.py
@@ -36,8 +36,7 @@ def run_jpeg(img_batch, device, quality=85):
         img = (img_batch[idx] * 255).to(torch.uint8)  # Convert each image in the batch
         jpeg_buffer = encode_jpeg(img, quality=quality)
         decoded_img = decode_jpeg(jpeg_buffer).to(device)
-        print(jpeg_buffer)
-        sys.exit()
+
         # Ensure decoded_img and original img are in the same dtype and range for comparison
         decoded_img = decoded_img.float() / 255
         

--- a/src/train_fcnn.py
+++ b/src/train_fcnn.py
@@ -59,13 +59,12 @@ def train(model, epochs, optimizer, scheduler, loss_fn, data_loader, device, ear
     return losses_train
 
 def main():
-    batch_size = 128
+    batch_size = 1024
     epochs = 50
     
     # Define the loss weights
-    lambda_ = [0.01, 0.05, 0.1, 0.5, 1, 2, 4, 8]
-    # lambda_ = [0.001]
-    
+    lambda_ = [0.00001, 0.0001, 0.001, 0.01, 0.05, 0.1, 0.5, 1, 2, 4, 8]
+
     data_loader = DataLoader(datasets.MNIST('../data/mnist',
                                              train=True,
                                              download=True,

--- a/src/utils.py
+++ b/src/utils.py
@@ -34,7 +34,7 @@ def device_manager(model):
         
         # Wrap models with DataParallel if more than one GPU is available
         if num_gpus > 1:
-            quantizer = nn.DataParallel(quantizer)
+            model = nn.DataParallel(model)
     else:
         device = torch.device("cpu")
         print("Using CPU.")
@@ -51,10 +51,10 @@ def calc_empirical_pmf(X):
 
     # Get unique values and their counts
     unique_values, counts = torch.unique(flattened, return_counts=True)
-
+    
     # Calculate probabilities
     probabilities = counts.float() / flattened.numel()
-
+    
     return probabilities
 
 def calc_empirical_rate(X):
@@ -63,6 +63,7 @@ def calc_empirical_rate(X):
     entropy = -torch.sum(probabilities * torch.log2(probabilities))
     return entropy
 
+# TODO Change std based on empirical rate of input data
 def calc_normal_rate(quantized_values, std=1.0):
     normal_dist = Normal(0, std)
     # Calculating negative log-likelihood as a proxy for rate


### PR DESCRIPTION
Wrote code that generated a rate-distortion graph for the jpeg encoding images by iterating through the quality parameter from 5 to 100 in increments of 5. Then overlayed this with the rate-distortion graph of the model. 

Also, made a preliminary change to the dataset file, getting rid of the NIH dataset and instead using (an untested) CheXpert_Dataset object to import our dataset. 